### PR TITLE
loads flags before use

### DIFF
--- a/model_search/metadata/ml_metadata_db.py
+++ b/model_search/metadata/ml_metadata_db.py
@@ -15,6 +15,7 @@
 
 import json
 import os
+import sys
 import random
 from absl import flags
 from absl import logging
@@ -50,7 +51,7 @@ flags.DEFINE_string(
     "config with this password is established.")
 
 FLAGS = flags.FLAGS
-
+FLAGS(sys.argv)
 
 class MLMetaData(metadata.MetaData):
   """An object which handles communicating with metadata db through MLMD."""


### PR DESCRIPTION
Reference to issue https://github.com/google/model_search/issues/6

Solution is to load flags before they are used: https://stackoverflow.com/questions/37582672/getting-unparsedflagaccesserror-when-trying-to-import-glog-in-python